### PR TITLE
Patch 4.1

### DIFF
--- a/InterruptReminder/InterruptReminder.lua
+++ b/InterruptReminder/InterruptReminder.lua
@@ -1,10 +1,29 @@
-local INTERRUPT_REMINDER_CLASS_INTERRUPT_SPELL -- Table of class spells that can interrupt
-local INTERRUPT_REMINDER_SPELL_ACTION_BAR_LOCATION -- Table of the interrupt spell in the action bars
-local INTERRUPT_REMINDER_IS_HIGHLIGHTED -- Boolean to keep track of whether the spell has been highlighted
-local INTERRUPT_REMINDER_INITIAL_LOAD -- Boolean for whether this is the first load (to counter some nil exceptions)
-local INTERRUPT_REMINDER_ALREADY_WARNED -- Boolean to keep track if user has been warned about missing interrupt spell
+local interruptReminder_ClassInterruptSpell -- Table of class spells that can interrupt
+local interruptReminder_SpellActionBarLocation -- Table of the interrupt spell in the action bars
+local interruptReminder_IsHighlighted -- Boolean to keep track of whether the spell has been highlighted
+local interruptReminder_InitialLoad -- Boolean for whether this is the first load (to counter some nil exceptions)
+local interruptReminder_AlreadyWarned -- Boolean to keep track if user has been warned about missing interrupt spell
+local interruptReminder_CurrentTargetCanBeAttacked -- Boolean to keep track whether the current target can be attacked
+local interruptReminder_ShowOverlayGlow = ActionButton_ShowOverlayGlow
+local interruptReminder_HideOverlayGlow = ActionButton_HideOverlayGlow
 
-local f = CreateFrame("Frame")
+local interruptReminder_InterruptSpellsSwitch = {
+    ['Death Knight'] = {'Mind Freeze', 'Asphyxiate', 'Strangulate', 'Death Grip'},
+    ['Demon Hunter'] = {'Disrupt'},
+    ['Druid'] = {'Skull Bash', 'Solar Beam'},
+    ['Evoker'] = {'Quell'},
+    ['Hunter'] = {'Counter Shot', 'Muzzle'},
+    ['Mage'] = {'Counterspell'},
+    ['Monk'] = {'Spear Hand Strike'},
+    ['Paladin'] = {'Rebuke', "Avenger's Shield"},
+    ['Priest'] = {'Silence'},
+    ['Rogue'] = {'Kick'},
+    ['Shaman'] = {'Wind Shear'},
+    ['Warlock'] = {'Spell Lock', 'Optical Blast', 'Axe Toss'},
+    ['Warrior'] = {'Pummel'}
+}
+
+local f = CreateFrame('Frame', 'InterruptReminder')
 
 function f:OnEvent(event, ...)
     self[event](self, event, ...)
@@ -12,23 +31,30 @@ end
 
 --[[
 Scan all of the player action bars and find the slot location for all interrupting spells for the player's class.
-Found in: https://www.wowinterface.com/forums/showthread.php?t=45731 - modified a bit to meet the needs of this mod
+Found in: https://www.wowinterface.com/forums/showthread.php?t=45731 - modified a bit to meet the needs of this addon
 --]]
 function FindInterruptSpell(spells)
-    local actionBars = {"Action", "MultiBarBottomLeft", "MultiBarBottomRight", "MultiBarRight", "MultiBarLeft", "MultiBar7", "MultiBar6", "MultiBar5"}
+    local actionBars = {'Action', 'MultiBarBottomLeft', 'MultiBarBottomRight', 'MultiBarRight', 'MultiBarLeft', 'MultiBar7', 'MultiBar6', 'MultiBar5'}
     local buttonLocations = {}
+    local lowerCases = {}
+
     for _, spell in ipairs(spells) do
         for _, barName in ipairs(actionBars) do
             for i = 1, 12 do
+                lowerCases = {}
                 local button = _G[barName .. 'Button' .. i]
                 local slot = button:GetPagedID() or button:CalculateAction() or button:GetAttribute('action')
                 if HasAction(slot) then
                     local actionType, id, _, actionName = GetActionInfo(slot)
-                    if actionType == "spell" then
+                    if actionType == 'spell' then
                         actionName = GetSpellInfo(id)
                     end
-                    if actionName and string.match(string.lower(actionName), string.lower(spell)) then
-                        table.insert(buttonLocations, button)
+                    if actionName then
+                        table.insert(lowerCases, string.lower(actionName))
+                        table.insert(lowerCases, string.lower(spell))
+                        if string.match(lowerCases[1], lowerCases[2]) then
+                            table.insert(buttonLocations, button)
+                        end
                     end
                 end
             end
@@ -37,39 +63,16 @@ function FindInterruptSpell(spells)
     return buttonLocations
 end
 
---[[
-On initial load (and when there's a loading screen), read the player class, use a makeshift switch to generate a
-list that class' interrupting spells, and find their location in the action bars
---]]
-function f:PLAYER_ENTERING_WORLD()
-    local playerClass = UnitClass("player")
-    local switch = {
-        ["Death Knight"] = {"Mind Freeze", "Asphyxiate", "Strangulate", "Death Grip"},
-        ["Demon Hunter"] = {"Disrupt"},
-        ["Druid"] = {"Skull Bash", "Solar Beam"},
-        ["Evoker"] = {"Quell"},
-        ["Hunter"] = {"Counter Shot", "Muzzle"},
-        ["Mage"] = {"Counterspell"},
-        ["Monk"] = {"Spear Hand Strike"},
-        ["Paladin"] = {"Rebuke", "Avenger's Shield"},
-        ["Priest"] = {"Silence"},
-        ["Rogue"] = {"Kick"},
-        ["Shaman"] = {"Wind Shear"},
-        ["Warlock"] = {"Spell Lock", "Optical Blast", "Axe Toss"},
-        ["Warrior"] = {"Pummel"}
-    }
-    INTERRUPT_REMINDER_CLASS_INTERRUPT_SPELL = switch[playerClass]
-    INTERRUPT_REMINDER_SPELL_ACTION_BAR_LOCATION = FindInterruptSpell(INTERRUPT_REMINDER_CLASS_INTERRUPT_SPELL)
-    INTERRUPT_REMINDER_IS_HIGHLIGHTED = 0
-    INTERRUPT_REMINDER_ALREADY_WARNED = 0
-    if next(INTERRUPT_REMINDER_SPELL_ACTION_BAR_LOCATION) == nil then
-        print("|cffffff00Warning (InterruptReminder): |cffffffffInterrupting spell(s) |" .. table.concat(INTERRUPT_REMINDER_CLASS_INTERRUPT_SPELL, ", ") .. "| not found in the action bar. Please move one to an action bar.")
-        if playerClass == "Warlock" then
-            print("|cffffff00Info (InterruptReminder): |cffffffffDetcted that player class is " .. playerClass .. ". Please move the interrupt ability to one of the action bars (not pet action bar) for AddOn to function correctly.")
-        end
-        INTERRUPT_REMINDER_ALREADY_WARNED = 1
+
+-- Get the current cooldown on all interrupting spells and save their status to a table
+function InterruptReminder_GetSpellCooldowns()
+    local onCooldown = {}
+
+    for _, spell in ipairs(interruptReminder_ClassInterruptSpell) do
+        local currentCooldown = GetSpellCooldown(spell)
+        table.insert(onCooldown, currentCooldown)
     end
-    INTERRUPT_REMINDER_INITIAL_LOAD = 1
+    return onCooldown
 end
 
 --[[
@@ -77,59 +80,93 @@ Check whether the target is attackable, and for every spell the player class has
 that spell. If the interrupting spell is off cooldown, the target's spell being cast is not instant and is
 interruptible, then highlight the action bar slot of the spell. Otherwise (if not already), hide the highlight.
 --]]
-function f:UNIT_SPELLCAST_START()
-    local attackable = UnitCanAttack("player", "target")
-    local onCooldown = {}
-    for _, spell in ipairs(INTERRUPT_REMINDER_CLASS_INTERRUPT_SPELL) do
-        local startTime = GetSpellCooldown(spell)
-        table.insert(onCooldown, startTime)
-    end
-    local _, _, _, startTime, endTime, _, _, notInterruptible, _ = UnitCastingInfo("target")
-    if attackable and not notInterruptible and startTime ~= nil and endTime ~= nil then
-        for _, cooldownedSpell in ipairs(onCooldown) do
+function InterruptReminder_HandleActiveTargetSpellCasting(interruptSpells, startTime, endTime, notInterruptible)
+    if interruptReminder_CurrentTargetCanBeAttacked and not notInterruptible and startTime ~= nil and endTime ~= nil then
+        for _, cooldownedSpell in ipairs(interruptSpells) do
             if cooldownedSpell == 0 then
-                if INTERRUPT_REMINDER_IS_HIGHLIGHTED == 0 then
-                    for _, location in ipairs(INTERRUPT_REMINDER_SPELL_ACTION_BAR_LOCATION) do
-                        ActionButton_ShowOverlayGlow(location)
+                if not interruptReminder_IsHighlighted then
+                    for _, location in ipairs(interruptReminder_SpellActionBarLocation) do
+                        interruptReminder_ShowOverlayGlow(location)
                     end
-                    INTERRUPT_REMINDER_IS_HIGHLIGHTED = 1
+                    interruptReminder_IsHighlighted = true
                 end
             end
         end
     else
-        for _, location in ipairs(INTERRUPT_REMINDER_SPELL_ACTION_BAR_LOCATION) do
-            ActionButton_HideOverlayGlow(location)
+        for _, location in ipairs(interruptReminder_SpellActionBarLocation) do
+            interruptReminder_HideOverlayGlow(location)
         end
-        INTERRUPT_REMINDER_IS_HIGHLIGHTED = 0
+        interruptReminder_IsHighlighted = false
     end
+end
+
+--[[
+In case the player switched targets, get whether the current target is either casting or channeling a spell that can
+be interrupted.
+--]]
+function InterruptReminder_HandleSwitchedTargetSpellCasting()
+    local name, _, _, startTime, endTime, _, _, notInterruptible, _ = UnitCastingInfo('target')
+
+    if name == nil then
+        name, _, _, startTime, endTime, _, notInterruptible, _ = UnitChannelInfo('target')
+    end
+    if name ~= nil then
+        InterruptReminder_HandleActiveTargetSpellCasting(InterruptReminder_GetSpellCooldowns(), startTime, endTime, notInterruptible)
+    end
+end
+
+function InterruptReminder_FilterCombatLogsForInterrupts()
+    local _, subEvent,_ , sourceGUID, _, _, _, destGUID, _, _, _, _, spellName = CombatLogGetCurrentEventInfo()
+    local playerGUID = UnitGUID('player')
+    local targetGUID = UnitGUID('target')
+
+    for _, spell in ipairs(interruptReminder_ClassInterruptSpell) do
+        if ((subEvent == 'SPELL_CAST_SUCCESS' and sourceGUID == playerGUID and spellName == spell)
+                or (subEvent == 'SPELL_CAST_SUCCESS' and sourceGUID == targetGUID)
+                or (subEvent == 'SPELL_INTERRUPT') and sourceGUID ~= playerGUID
+                and destGUID == targetGUID) then
+            for _, location in ipairs(interruptReminder_SpellActionBarLocation) do
+                interruptReminder_HideOverlayGlow(location)
+            end
+            interruptReminder_IsHighlighted = false
+        end
+    end
+end
+
+
+--[[
+On initial load (and when there's a loading screen), read the player class, use a makeshift switch to generate a
+list that class' interrupting spells, and find their location in the action bars
+--]]
+function f:PLAYER_ENTERING_WORLD()
+    local playerClass = UnitClass('player')
+
+    interruptReminder_ClassInterruptSpell = interruptReminder_InterruptSpellsSwitch[playerClass]
+    interruptReminder_SpellActionBarLocation = FindInterruptSpell(interruptReminder_ClassInterruptSpell)
+    interruptReminder_IsHighlighted = false
+    interruptReminder_AlreadyWarned = false
+    if ipairs(interruptReminder_SpellActionBarLocation) == nil then
+        print("|cffffff00Warning (InterruptReminder): |cffffffffInterrupting spell(s) |" .. table.concat(interruptReminder_ClassInterruptSpell, ", ") .. "| not found in the action bar. Please move one to an action bar.")
+        if playerClass == 'Warlock' then
+            print("|cffffff00Info (InterruptReminder): |cffffffffDetcted that player class is " .. playerClass .. ". Please move the interrupt ability to one of the action bars (not pet action bar) for AddOn to function correctly.")
+        end
+        interruptReminder_AlreadyWarned = true
+    end
+    interruptReminder_InitialLoad = true
+end
+
+-- Unit starts casting a spell, executes InterruptReminder_HighlightInterruptSpells, which handles ability highlighting
+function f:UNIT_SPELLCAST_START()
+    local _, _, _, startTime, endTime, _, _, notInterruptible, _ = UnitCastingInfo('target')
+
+    InterruptReminder_HandleActiveTargetSpellCasting(InterruptReminder_GetSpellCooldowns(), startTime, endTime, notInterruptible)
 end
 
 -- Same as UNIT_SPELLCAST_START but for channeling spells
 function f:UNIT_SPELLCAST_CHANNEL_START()
-    local attackable = UnitCanAttack("player", "target")
-    local onCooldown = {}
-    for _, spell in ipairs(INTERRUPT_REMINDER_CLASS_INTERRUPT_SPELL) do
-        local startTime = GetSpellCooldown(spell)
-        table.insert(onCooldown, startTime)
-    end
-    local _, _, _, startTime, endTime, _, notInterruptible, _ = UnitChannelInfo("target")
-    if attackable and not notInterruptible and startTime ~= nil and endTime ~= nil then
-        for _, cooldownedSpell in ipairs(onCooldown) do
-            if cooldownedSpell == 0 then
-                if INTERRUPT_REMINDER_IS_HIGHLIGHTED == 0 then
-                    for _, location in ipairs(INTERRUPT_REMINDER_SPELL_ACTION_BAR_LOCATION) do
-                        ActionButton_ShowOverlayGlow(location)
-                    end
-                    INTERRUPT_REMINDER_IS_HIGHLIGHTED = 1
-                end
-            end
-        end
-    else
-        for _, location in ipairs(INTERRUPT_REMINDER_SPELL_ACTION_BAR_LOCATION) do
-            ActionButton_HideOverlayGlow(location)
-        end
-        INTERRUPT_REMINDER_IS_HIGHLIGHTED = 0
-    end
+    local _, _, _, startTime, endTime, _, notInterruptible, _ = UnitChannelInfo('target')
+
+    InterruptReminder_HandleActiveTargetSpellCasting(InterruptReminder_GetSpellCooldowns(), startTime, endTime, notInterruptible)
 end
 
 --[[
@@ -137,47 +174,45 @@ If the player has cast his interrupt spell, the target has finished casting his 
 the target, then remove the overlay.
 --]]
 function f:COMBAT_LOG_EVENT_UNFILTERED()
-    local _, subEvent,_ , sourceGUID, _, _, _, destGUID, _, _, _, _, spellName = CombatLogGetCurrentEventInfo()
-    for _, spell in ipairs(INTERRUPT_REMINDER_CLASS_INTERRUPT_SPELL) do
-        if ((subEvent == "SPELL_CAST_SUCCESS" and sourceGUID == UnitGUID("player") and spellName == spell)
-                or (subEvent == "SPELL_CAST_SUCCESS" and sourceGUID == UnitGUID("target"))
-                or (subEvent == "SPELL_INTERRUPT") and sourceGUID ~= UnitGUID("player")
-                and destGUID == UnitGUID("target")) then
-            for _, location in ipairs(INTERRUPT_REMINDER_SPELL_ACTION_BAR_LOCATION) do
-                ActionButton_HideOverlayGlow(location)
-            end
-            INTERRUPT_REMINDER_IS_HIGHLIGHTED = 0
-        end
-    end
+    InterruptReminder_FilterCombatLogsForInterrupts()
 end
 
--- If the player changed the target, hide the overlay glow
+--[[
+If the player changed the target, hide the overlay glow, get information about the new target and execute
+InterruptReminder_HandleSwitchedTargetActiveCasting, which handles ongoing castings/channeling of new target
+--]]
 function f:PLAYER_TARGET_CHANGED()
-    if (INTERRUPT_REMINDER_IS_HIGHLIGHTED == 1) then
-        for _, location in ipairs(INTERRUPT_REMINDER_SPELL_ACTION_BAR_LOCATION) do
-            ActionButton_HideOverlayGlow(location)
+    if interruptReminder_IsHighlighted then
+        for _, location in ipairs(interruptReminder_SpellActionBarLocation) do
+            interruptReminder_HideOverlayGlow(location)
         end
-        INTERRUPT_REMINDER_IS_HIGHLIGHTED = 0
+        interruptReminder_IsHighlighted = false
     end
+    if UnitCanAttack('player', 'target') then
+        interruptReminder_CurrentTargetCanBeAttacked = true
+    else
+        interruptReminder_CurrentTargetCanBeAttacked = false
+    end
+    InterruptReminder_HandleSwitchedTargetSpellCasting()
 end
 
 -- Fires when the player has updates his action bar to get the new location of the interrupting spell
 function f:ACTIONBAR_SLOT_CHANGED()
-    if INTERRUPT_REMINDER_INITIAL_LOAD == 1 then
-        if next(INTERRUPT_REMINDER_CLASS_INTERRUPT_SPELL) ~= nil then
-            INTERRUPT_REMINDER_SPELL_ACTION_BAR_LOCATION = FindInterruptSpell(INTERRUPT_REMINDER_CLASS_INTERRUPT_SPELL)
+    if interruptReminder_InitialLoad then
+        if next(interruptReminder_ClassInterruptSpell) ~= nil then
+            interruptReminder_SpellActionBarLocation = FindInterruptSpell(interruptReminder_ClassInterruptSpell)
         end
-        if next(INTERRUPT_REMINDER_SPELL_ACTION_BAR_LOCATION) == nil and INTERRUPT_REMINDER_ALREADY_WARNED == 0 then
-            print("|cffffff00Warning (InterruptReminder): |cffffffffInterrupting spell(s) |" .. table.concat(INTERRUPT_REMINDER_CLASS_INTERRUPT_SPELL, ", ") .. "| not found in the action bar. Please move one to an action bar.")
-            INTERRUPT_REMINDER_ALREADY_WARNED = 1
+        if next(interruptReminder_SpellActionBarLocation) == nil and not interruptReminder_AlreadyWarned then
+            print("|cffffff00Warning (InterruptReminder): |cffffffffInterrupting spell(s) |" .. table.concat(interruptReminder_ClassInterruptSpell, ", ") .. "| not found in the action bar. Please move one to an action bar.")
+            interruptReminder_AlreadyWarned = true
         end
     end
 end
 
-f:RegisterEvent("PLAYER_ENTERING_WORLD")
-f:RegisterEvent("UNIT_SPELLCAST_START")
-f:RegisterEvent("UNIT_SPELLCAST_CHANNEL_START")
-f:RegisterEvent("COMBAT_LOG_EVENT_UNFILTERED")
-f:RegisterEvent("PLAYER_TARGET_CHANGED")
-f:RegisterEvent("ACTIONBAR_SLOT_CHANGED")
-f:SetScript("OnEvent", f.OnEvent)
+f:RegisterEvent('PLAYER_ENTERING_WORLD')
+f:RegisterEvent('UNIT_SPELLCAST_START')
+f:RegisterEvent('UNIT_SPELLCAST_CHANNEL_START')
+f:RegisterEvent('COMBAT_LOG_EVENT_UNFILTERED')
+f:RegisterEvent('PLAYER_TARGET_CHANGED')
+f:RegisterEvent('ACTIONBAR_SLOT_CHANGED')
+f:SetScript('OnEvent', f.OnEvent)

--- a/InterruptReminder/InterruptReminder.lua
+++ b/InterruptReminder/InterruptReminder.lua
@@ -1,47 +1,22 @@
-local interruptReminder_ClassInterruptSpell -- Table of class spells that can interrupt
-local interruptReminder_SpellActionBarLocation -- Table of the interrupt spell in the action bars
-local interruptReminder_IsHighlighted -- Boolean to keep track of whether the spell has been highlighted
-local interruptReminder_InitialLoad -- Boolean for whether this is the first load (to counter some nil exceptions)
-local interruptReminder_AlreadyWarned -- Boolean to keep track if user has been warned about missing interrupt spell
-local interruptReminder_CurrentTargetCanBeAttacked -- Boolean to keep track whether the current target can be attacked
-local interruptReminder_ShowOverlayGlow = ActionButton_ShowOverlayGlow
-local interruptReminder_HideOverlayGlow = ActionButton_HideOverlayGlow
-
-local interruptReminder_InterruptSpellsSwitch = {
-    ['Death Knight'] = {'Mind Freeze', 'Asphyxiate', 'Strangulate', 'Death Grip'},
-    ['Demon Hunter'] = {'Disrupt'},
-    ['Druid'] = {'Skull Bash', 'Solar Beam'},
-    ['Evoker'] = {'Quell'},
-    ['Hunter'] = {'Counter Shot', 'Muzzle'},
-    ['Mage'] = {'Counterspell'},
-    ['Monk'] = {'Spear Hand Strike'},
-    ['Paladin'] = {'Rebuke', "Avenger's Shield"},
-    ['Priest'] = {'Silence'},
-    ['Rogue'] = {'Kick'},
-    ['Shaman'] = {'Wind Shear'},
-    ['Warlock'] = {'Spell Lock', 'Optical Blast', 'Axe Toss'},
-    ['Warrior'] = {'Pummel'}
-}
+local interruptReminder_Table = {}
 
 local f = CreateFrame('Frame', 'InterruptReminder')
+local LibButtonGlow = LibStub("LibButtonGlow-1.0")
 
 function f:OnEvent(event, ...)
     self[event](self, event, ...)
 end
 
---[[
-Scan all of the player action bars and find the slot location for all interrupting spells for the player's class.
-Found in: https://www.wowinterface.com/forums/showthread.php?t=45731 - modified a bit to meet the needs of this addon
---]]
-function FindInterruptSpell(spells)
+
+---Scan all of the player action bars and find the slot location for all interrupting spells for the player's class.
+--- Found in: https://www.wowinterface.com/forums/showthread.php?t=45731 - modified a bit to meet the needs of this addon
+local function find_all_interrupt_spell(spells)
     local actionBars = {'Action', 'MultiBarBottomLeft', 'MultiBarBottomRight', 'MultiBarRight', 'MultiBarLeft', 'MultiBar7', 'MultiBar6', 'MultiBar5'}
     local buttonLocations = {}
-    local lowerCases = {}
 
     for _, spell in ipairs(spells) do
         for _, barName in ipairs(actionBars) do
             for i = 1, 12 do
-                lowerCases = {}
                 local button = _G[barName .. 'Button' .. i]
                 local slot = button:GetPagedID() or button:CalculateAction() or button:GetAttribute('action')
                 if HasAction(slot) then
@@ -50,9 +25,7 @@ function FindInterruptSpell(spells)
                         actionName = GetSpellInfo(id)
                     end
                     if actionName then
-                        table.insert(lowerCases, string.lower(actionName))
-                        table.insert(lowerCases, string.lower(spell))
-                        if string.match(lowerCases[1], lowerCases[2]) then
+                        if string.lower(actionName) == string.lower(spell) then
                             table.insert(buttonLocations, button)
                         end
                     end
@@ -64,147 +37,228 @@ function FindInterruptSpell(spells)
 end
 
 
--- Get the current cooldown on all interrupting spells and save their status to a table
-function InterruptReminder_GetSpellCooldowns()
-    local onCooldown = {}
+---Same as InterruptReminder_find_all_interrupt_spell, but for a single spell
+local function find_interrupt_spell(spell)
+    local actionBars = {'Action', 'MultiBarBottomLeft', 'MultiBarBottomRight', 'MultiBarRight', 'MultiBarLeft', 'MultiBar7', 'MultiBar6', 'MultiBar5'}
 
-    for _, spell in ipairs(interruptReminder_ClassInterruptSpell) do
-        local currentCooldown = GetSpellCooldown(spell)
-        table.insert(onCooldown, currentCooldown)
-    end
-    return onCooldown
-end
-
---[[
-Check whether the target is attackable, and for every spell the player class has, get the current cooldown status of
-that spell. If the interrupting spell is off cooldown, the target's spell being cast is not instant and is
-interruptible, then highlight the action bar slot of the spell. Otherwise (if not already), hide the highlight.
---]]
-function InterruptReminder_HandleActiveTargetSpellCasting(interruptSpells, startTime, endTime, notInterruptible)
-    if interruptReminder_CurrentTargetCanBeAttacked and not notInterruptible and startTime ~= nil and endTime ~= nil then
-        for _, cooldownedSpell in ipairs(interruptSpells) do
-            if cooldownedSpell == 0 then
-                if not interruptReminder_IsHighlighted then
-                    for _, location in ipairs(interruptReminder_SpellActionBarLocation) do
-                        interruptReminder_ShowOverlayGlow(location)
+    for _, barName in ipairs(actionBars) do
+        for i = 1, 12 do
+            local button = _G[barName .. 'Button' .. i]
+            local slot = button:GetPagedID() or button:CalculateAction() or button:GetAttribute('action')
+            if HasAction(slot) then
+                local actionType, id, _, actionName = GetActionInfo(slot)
+                if actionType == 'spell' then
+                    actionName = GetSpellInfo(id)
+                end
+                if actionName then
+                    if string.lower(actionName) == string.lower(spell) then
+                        return button
                     end
-                    interruptReminder_IsHighlighted = true
                 end
             end
         end
-    else
-        for _, location in ipairs(interruptReminder_SpellActionBarLocation) do
-            interruptReminder_HideOverlayGlow(location)
-        end
-        interruptReminder_IsHighlighted = false
     end
 end
 
---[[
-In case the player switched targets, get whether the current target is either casting or channeling a spell that can
-be interrupted.
---]]
-function InterruptReminder_HandleSwitchedTargetSpellCasting()
-    local name, _, _, startTime, endTime, _, _, notInterruptible, _ = UnitCastingInfo('target')
 
+---Retrieves the cooldown status of a list of spells and their corresponding location on the action bar(s).
+---Returns two tables: one for spells ready to be cast and another for spells that are still on cool down.
+---Parameters:
+--- class_spells (table): A list of spell names (strings) to check the cooldown for.
+---Returns:
+--- readyToCast (table): A table of spells ready to be cast.
+--- stillOnCooldown (table): A table of spells still on cooldown.
+local function get_spell_cooldowns(class_spells)
+    local readyToCast = {}
+    local stillOnCooldown = {}
+
+    for i = 1, #class_spells do
+        local start, duration = GetSpellCooldown(class_spells[i])
+        local spellLocation = find_interrupt_spell(class_spells[i])
+        if start == 0 then
+            table.insert(readyToCast, {['cooldown']=start, ['location']=spellLocation})
+        end
+        if start ~= 0 then
+            -- Add a 0.01 overhead to ensure the spell gets highlighted after it is off cooldown
+            local calculateTimeRemaining = (start + duration - GetTime()) + 0.01
+            -- Safety check to ensure we don't save a negative number by mistake
+            if calculateTimeRemaining > 0 then
+                table.insert(stillOnCooldown, {['cooldown']=calculateTimeRemaining, ['location']=spellLocation})
+            end
+        end
+    end
+    return readyToCast, stillOnCooldown
+end
+
+
+---Checks if the target is casting interruptible or channeling a spell that can be interrupted.
+---Parameters:
+--- targetCanBeAttacked (boolean): Indicates whether the target can be attacked.
+---Returns:
+--- (boolean) Whether the target is casting or channeling a spell that can be interrupted.
+local function is_target_casting_interruptible_spell(targetCanBeAttacked)
+    local name, _, _, startTime, endTime, _, _, notInterruptible, _ = UnitCastingInfo('target')
     if name == nil then
         name, _, _, startTime, endTime, _, notInterruptible, _ = UnitChannelInfo('target')
     end
-    if name ~= nil then
-        InterruptReminder_HandleActiveTargetSpellCasting(InterruptReminder_GetSpellCooldowns(), startTime, endTime, notInterruptible)
+    return targetCanBeAttacked and not notInterruptible and startTime ~= nil and endTime ~= nil
+end
+
+
+---Handles the logic for highlighting interruptible spells on the active target (whether target can be interrupted is
+--- deduced during PLAYER_TARGET_CHANGED event).
+---In case a spell is not in cooldown, highlight the spell at its action bar location.
+---In case a spell is in cooldown, use C_Timer.After to check whether by the time it is off cooldown, that target
+--- can still be interrupted, in which case it will highlight the ability at its location.
+local function handle_active_target_spell_casting()
+    local targetHighlighted = interruptReminder_Table['IsHighlighted']
+    local readyToCast, stillOnCooldown = get_spell_cooldowns(interruptReminder_Table['ClassInterruptSpell'])
+
+    if is_target_casting_interruptible_spell(interruptReminder_Table['CurrentTargetCanBeAttacked']) then
+        for i = 1, #readyToCast do
+            if not targetHighlighted then
+                LibButtonGlow.ShowOverlayGlow(readyToCast[i].location)
+            end
+            interruptReminder_Table['IsHighlighted'] = true
+        end
+    end
+
+    for i = 1, #stillOnCooldown do
+        C_Timer.After(stillOnCooldown[i].cooldown, function()
+            targetHighlighted = interruptReminder_Table['IsHighlighted']
+            if is_target_casting_interruptible_spell(interruptReminder_Table['CurrentTargetCanBeAttacked']) then
+                    if not targetHighlighted then
+                        LibButtonGlow.ShowOverlayGlow(stillOnCooldown[i].location)
+                    end
+                    interruptReminder_Table['IsHighlighted'] = true
+            end
+        end)
     end
 end
 
-function InterruptReminder_FilterCombatLogsForInterrupts()
-    local _, subEvent,_ , sourceGUID, _, _, _, destGUID, _, _, _, _, spellName = CombatLogGetCurrentEventInfo()
+
+---Filter combat logs to detect interrupts (or successful target casts) on the target to hide the highlighting on all spell action bar locations
+local function filter_combat_logs_for_interrupts()
+    local subEvent, _, sourceGUID, _, _, _, destGUID, _, _, _, _, spellName = select(2, CombatLogGetCurrentEventInfo())
+    local classInterruptSpells = interruptReminder_Table['ClassInterruptSpell']
+    local spellActionBarLocation = interruptReminder_Table['SpellActionBarLocation']
+    local isHighlighted = interruptReminder_Table['IsHighlighted']
     local playerGUID = UnitGUID('player')
     local targetGUID = UnitGUID('target')
 
-    for _, spell in ipairs(interruptReminder_ClassInterruptSpell) do
-        if ((subEvent == 'SPELL_CAST_SUCCESS' and sourceGUID == playerGUID and spellName == spell)
-                or (subEvent == 'SPELL_CAST_SUCCESS' and sourceGUID == targetGUID)
-                or (subEvent == 'SPELL_INTERRUPT') and sourceGUID ~= playerGUID
-                and destGUID == targetGUID) then
-            for _, location in ipairs(interruptReminder_SpellActionBarLocation) do
-                interruptReminder_HideOverlayGlow(location)
+    -- Used to determine interrupt cases
+    local spellCastSuccessEvent = (subEvent == 'SPELL_CAST_SUCCESS')
+    local isPlayerSource = (sourceGUID == playerGUID)
+    local isTargetSource = (sourceGUID == targetGUID)
+    local isInterruptEvent = (subEvent == 'SPELL_INTERRUPT')
+    local isOutsideInterrupt = (sourceGUID ~= playerGUID and destGUID == targetGUID)
+
+    for _, spell in ipairs(classInterruptSpells) do
+        if ((spellCastSuccessEvent and isPlayerSource and spellName == spell)
+                or (spellCastSuccessEvent and isTargetSource)
+                or (isInterruptEvent and isOutsideInterrupt))then
+            if isHighlighted then
+                for _, location in ipairs(spellActionBarLocation) do
+                    LibButtonGlow.HideOverlayGlow(location)
+                end
             end
-            interruptReminder_IsHighlighted = false
+            interruptReminder_Table['IsHighlighted'] = false
+            break
         end
     end
 end
 
 
---[[
-On initial load (and when there's a loading screen), read the player class, use a makeshift switch to generate a
-list that class' interrupting spells, and find their location in the action bars
---]]
+---Triggers when the player enters the world (or any phase, or on /reload)
 function f:PLAYER_ENTERING_WORLD()
     local playerClass = UnitClass('player')
+    -- Makeshift switch to map each class' interrupt spells to a class
+    local interruptReminder_InterruptSpellsSwitch = {
+        ['Death Knight'] = {'Mind Freeze', 'Asphyxiate', 'Strangulate', 'Death Grip'},
+        ['Demon Hunter'] = {'Disrupt'},
+        ['Druid'] = {'Skull Bash', 'Solar Beam'},
+        ['Evoker'] = {'Quell'},
+        ['Hunter'] = {'Counter Shot', 'Muzzle'},
+        ['Mage'] = {'Counterspell'},
+        ['Monk'] = {'Spear Hand Strike'},
+        ['Paladin'] = {'Rebuke', "Avenger's Shield"},
+        ['Priest'] = {'Silence'},
+        ['Rogue'] = {'Kick'},
+        ['Shaman'] = {'Wind Shear'},
+        ['Warlock'] = {'Spell Lock', 'Optical Blast', 'Axe Toss'},
+        ['Warrior'] = {'Pummel'}
+    }
+    -- Grab the player's interrupt spells based on playerClass and the makeshift switch
+    interruptReminder_Table['ClassInterruptSpell'] = interruptReminder_InterruptSpellsSwitch[playerClass]
 
-    interruptReminder_ClassInterruptSpell = interruptReminder_InterruptSpellsSwitch[playerClass]
-    interruptReminder_SpellActionBarLocation = FindInterruptSpell(interruptReminder_ClassInterruptSpell)
-    interruptReminder_IsHighlighted = false
-    interruptReminder_AlreadyWarned = false
-    if ipairs(interruptReminder_SpellActionBarLocation) == nil then
-        print("|cffffff00Warning (InterruptReminder): |cffffffffInterrupting spell(s) |" .. table.concat(interruptReminder_ClassInterruptSpell, ", ") .. "| not found in the action bar. Please move one to an action bar.")
+    -- Find the location of those spells on the action bars
+    interruptReminder_Table['SpellActionBarLocation'] = find_all_interrupt_spell(interruptReminder_Table['ClassInterruptSpell'])
+
+    -- Initial values for interruptReminder_Table
+    interruptReminder_Table['IsHighlighted'] = false
+    interruptReminder_Table['AlreadyWarned'] = false
+    interruptReminder_Table['CurrentTargetCanBeAttacked'] = false
+
+    -- Check if the action bars do not contain any interrupt spell, in which case a warning will be thrown
+    if next(interruptReminder_Table['SpellActionBarLocation']) == nil then
+        local tableConcat = table.concat(interruptReminder_Table['ClassInterruptSpell'], ", ")
+        print("|cffffff00Warning (InterruptReminder): |cffffffffInterrupting spell(s) |" .. tableConcat .. "| not found in the action bar. Please move one to an action bar.")
         if playerClass == 'Warlock' then
             print("|cffffff00Info (InterruptReminder): |cffffffffDetcted that player class is " .. playerClass .. ". Please move the interrupt ability to one of the action bars (not pet action bar) for AddOn to function correctly.")
         end
-        interruptReminder_AlreadyWarned = true
+        interruptReminder_Table['AlreadyWarned'] = true
     end
-    interruptReminder_InitialLoad = true
+    interruptReminder_Table['InitialLoad'] = true
 end
 
--- Unit starts casting a spell, executes InterruptReminder_HighlightInterruptSpells, which handles ability highlighting
-function f:UNIT_SPELLCAST_START()
-    local _, _, _, startTime, endTime, _, _, notInterruptible, _ = UnitCastingInfo('target')
+function f:UNIT_SPELLCAST_START() handle_active_target_spell_casting() end
 
-    InterruptReminder_HandleActiveTargetSpellCasting(InterruptReminder_GetSpellCooldowns(), startTime, endTime, notInterruptible)
-end
+function f:UNIT_SPELLCAST_CHANNEL_START() handle_active_target_spell_casting() end
 
--- Same as UNIT_SPELLCAST_START but for channeling spells
-function f:UNIT_SPELLCAST_CHANNEL_START()
-    local _, _, _, startTime, endTime, _, notInterruptible, _ = UnitChannelInfo('target')
+function f:COMBAT_LOG_EVENT_UNFILTERED() filter_combat_logs_for_interrupts() end
 
-    InterruptReminder_HandleActiveTargetSpellCasting(InterruptReminder_GetSpellCooldowns(), startTime, endTime, notInterruptible)
-end
 
---[[
-If the player has cast his interrupt spell, the target has finished casting his spell, or someone else has interrupted
-the target, then remove the overlay.
---]]
-function f:COMBAT_LOG_EVENT_UNFILTERED()
-    InterruptReminder_FilterCombatLogsForInterrupts()
-end
-
---[[
-If the player changed the target, hide the overlay glow, get information about the new target and execute
-InterruptReminder_HandleSwitchedTargetActiveCasting, which handles ongoing castings/channeling of new target
---]]
+---Triggers when the player changes his target (or gains one)
 function f:PLAYER_TARGET_CHANGED()
-    if interruptReminder_IsHighlighted then
-        for _, location in ipairs(interruptReminder_SpellActionBarLocation) do
-            interruptReminder_HideOverlayGlow(location)
+    local targetHighlighted = interruptReminder_Table['IsHighlighted']
+    local spellActionBarLocation = interruptReminder_Table['SpellActionBarLocation']
+
+    -- If the interrupt spells were already highlighted, unhighlight them all.
+    if targetHighlighted then
+        for _, location in ipairs(spellActionBarLocation) do
+            LibButtonGlow.HideOverlayGlow(location)
         end
-        interruptReminder_IsHighlighted = false
+        interruptReminder_Table['IsHighlighted'] = false
     end
+
+    -- Check if the target is valid to attack by the player (e.g. not a friendly player, friendly npc, a pet...)
     if UnitCanAttack('player', 'target') then
-        interruptReminder_CurrentTargetCanBeAttacked = true
+        interruptReminder_Table['CurrentTargetCanBeAttacked'] = true
     else
-        interruptReminder_CurrentTargetCanBeAttacked = false
+        interruptReminder_Table['CurrentTargetCanBeAttacked'] = false
     end
-    InterruptReminder_HandleSwitchedTargetSpellCasting()
+
+    -- When the player gains his initial target or switches to a target, check whether the target is casting an
+    -- interruptible spell, and proceed to handle the highlighting of spells in the action bars
+    handle_active_target_spell_casting()
 end
 
--- Fires when the player has updates his action bar to get the new location of the interrupting spell
+
+---Triggers when the player updates his action bar. Checks if the interrupt spells are still there and throws a warning
+--- if they are missing. Warning will not be thrown as long as at least one is present.
 function f:ACTIONBAR_SLOT_CHANGED()
-    if interruptReminder_InitialLoad then
-        if next(interruptReminder_ClassInterruptSpell) ~= nil then
-            interruptReminder_SpellActionBarLocation = FindInterruptSpell(interruptReminder_ClassInterruptSpell)
+    local initialLoad = interruptReminder_Table['InitialLoad']
+    local classInterruptSpells = interruptReminder_Table['ClassInterruptSpell']
+    local alreadyWarned = interruptReminder_Table['AlreadyWarned']
+
+    if initialLoad then
+        if next(classInterruptSpells) ~= nil then
+            interruptReminder_Table['SpellActionBarLocation'] = find_all_interrupt_spell(classInterruptSpells)
         end
-        if next(interruptReminder_SpellActionBarLocation) == nil and not interruptReminder_AlreadyWarned then
-            print("|cffffff00Warning (InterruptReminder): |cffffffffInterrupting spell(s) |" .. table.concat(interruptReminder_ClassInterruptSpell, ", ") .. "| not found in the action bar. Please move one to an action bar.")
-            interruptReminder_AlreadyWarned = true
+        if next(interruptReminder_Table['SpellActionBarLocation']) == nil and not alreadyWarned then
+            local tableConcat = table.concat(interruptReminder_Table['ClassInterruptSpell'], ", ")
+            print("|cffffff00Warning (InterruptReminder): |cffffffffInterrupting spell(s) |" .. tableConcat .. "| not found in the action bar. Please move one to an action bar.")
+            interruptReminder_Table['AlreadyWarned'] = true
         end
     end
 end

--- a/InterruptReminder/InterruptReminder.toc
+++ b/InterruptReminder/InterruptReminder.toc
@@ -1,6 +1,9 @@
 ## Interface: 100100
-## Version: 1.1.0
+## Version: 1.2.0
 ## Title: Interrupt Reminder
 ## Author: AgentRG
+## OptionalDeps: LibButtonGlow-1.0
 
+Libs\LibButtonGlow-1.0\LibStub\LibStub.lua
+Libs\LibButtonGlow-1.0\LibButtonGlow-1.0.lua
 InterruptReminder.lua

--- a/InterruptReminder/Libs/LibButtonGlow-1.0/LibButtonGlow-1.0.lua
+++ b/InterruptReminder/Libs/LibButtonGlow-1.0/LibButtonGlow-1.0.lua
@@ -1,0 +1,256 @@
+--[[
+Copyright (c) 2015-2020, Hendrik "nevcairiel" Leppkes <h.leppkes@gmail.com>
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without 
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice, 
+      this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright notice, 
+      this list of conditions and the following disclaimer in the documentation 
+      and/or other materials provided with the distribution.
+    * Neither the name of the developer nor the names of its contributors 
+      may be used to endorse or promote products derived from this software without 
+      specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+]]
+local MAJOR_VERSION = "LibButtonGlow-1.0"
+local MINOR_VERSION = 8
+
+if not LibStub then error(MAJOR_VERSION .. " requires LibStub.") end
+local lib, oldversion = LibStub:NewLibrary(MAJOR_VERSION, MINOR_VERSION)
+if not lib then return end
+
+local Masque = LibStub("Masque", true)
+
+lib.unusedOverlays = lib.unusedOverlays or {}
+lib.numOverlays = lib.numOverlays or 0
+
+local tinsert, tremove, tostring = table.insert, table.remove, tostring
+
+local function OverlayGlowAnimOutFinished(animGroup)
+	local overlay = animGroup:GetParent()
+	local frame = overlay:GetParent()
+	overlay:Hide()
+	tinsert(lib.unusedOverlays, overlay)
+	frame.__LBGoverlay = nil
+end
+
+local function OverlayGlow_OnHide(self)
+	if self.animOut:IsPlaying() then
+		self.animOut:Stop()
+		OverlayGlowAnimOutFinished(self.animOut)
+	end
+end
+
+local function OverlayGlow_OnUpdate(self, elapsed)
+	AnimateTexCoords(self.ants, 256, 256, 48, 48, 22, elapsed, 0.01)
+	local cooldown = self:GetParent().cooldown
+	-- we need some threshold to avoid dimming the glow during the gdc
+	-- (using 1500 exactly seems risky, what if casting speed is slowed or something?)
+	if cooldown and cooldown:IsShown() and cooldown:GetCooldownDuration() > 3000 then
+		self:SetAlpha(0.5)
+	else
+		self:SetAlpha(1.0)
+	end
+end
+
+local function CreateScaleAnim(group, target, order, duration, x, y, delay)
+	local scale = group:CreateAnimation("Scale")
+	scale:SetTarget(target)
+	scale:SetOrder(order)
+	scale:SetDuration(duration)
+	scale:SetScale(x, y)
+
+	if delay then
+		scale:SetStartDelay(delay)
+	end
+end
+
+local function CreateAlphaAnim(group, target, order, duration, fromAlpha, toAlpha, delay)
+	local alpha = group:CreateAnimation("Alpha")
+	alpha:SetTarget(target)
+	alpha:SetOrder(order)
+	alpha:SetDuration(duration)
+	alpha:SetFromAlpha(fromAlpha)
+	alpha:SetToAlpha(toAlpha)
+
+	if delay then
+		alpha:SetStartDelay(delay)
+	end
+end
+
+local function AnimIn_OnPlay(group)
+	local frame = group:GetParent()
+	local frameWidth, frameHeight = frame:GetSize()
+	frame.spark:SetSize(frameWidth, frameHeight)
+	frame.spark:SetAlpha(0.3)
+	frame.innerGlow:SetSize(frameWidth / 2, frameHeight / 2)
+	frame.innerGlow:SetAlpha(1.0)
+	frame.innerGlowOver:SetAlpha(1.0)
+	frame.outerGlow:SetSize(frameWidth * 2, frameHeight * 2)
+	frame.outerGlow:SetAlpha(1.0)
+	frame.outerGlowOver:SetAlpha(1.0)
+	frame.ants:SetSize(frameWidth * 0.85, frameHeight * 0.85)
+	frame.ants:SetAlpha(0)
+	frame:Show()
+end
+
+local function AnimIn_OnFinished(group)
+	local frame = group:GetParent()
+	local frameWidth, frameHeight = frame:GetSize()
+	frame.spark:SetAlpha(0)
+	frame.innerGlow:SetAlpha(0)
+	frame.innerGlow:SetSize(frameWidth, frameHeight)
+	frame.innerGlowOver:SetAlpha(0.0)
+	frame.outerGlow:SetSize(frameWidth, frameHeight)
+	frame.outerGlowOver:SetAlpha(0.0)
+	frame.outerGlowOver:SetSize(frameWidth, frameHeight)
+	frame.ants:SetAlpha(1.0)
+end
+
+local function CreateOverlayGlow()
+	lib.numOverlays = lib.numOverlays + 1
+
+	-- create frame and textures
+	local name = "ButtonGlowOverlay" .. tostring(lib.numOverlays)
+	local overlay = CreateFrame("Frame", name, UIParent)
+
+	-- spark
+	overlay.spark = overlay:CreateTexture(name .. "Spark", "BACKGROUND")
+	overlay.spark:SetPoint("CENTER")
+	overlay.spark:SetAlpha(0)
+	overlay.spark:SetTexture([[Interface\SpellActivationOverlay\IconAlert]])
+	overlay.spark:SetTexCoord(0.00781250, 0.61718750, 0.00390625, 0.26953125)
+
+	-- inner glow
+	overlay.innerGlow = overlay:CreateTexture(name .. "InnerGlow", "ARTWORK")
+	overlay.innerGlow:SetPoint("CENTER")
+	overlay.innerGlow:SetAlpha(0)
+	overlay.innerGlow:SetTexture([[Interface\SpellActivationOverlay\IconAlert]])
+	overlay.innerGlow:SetTexCoord(0.00781250, 0.50781250, 0.27734375, 0.52734375)
+
+	-- inner glow over
+	overlay.innerGlowOver = overlay:CreateTexture(name .. "InnerGlowOver", "ARTWORK")
+	overlay.innerGlowOver:SetPoint("TOPLEFT", overlay.innerGlow, "TOPLEFT")
+	overlay.innerGlowOver:SetPoint("BOTTOMRIGHT", overlay.innerGlow, "BOTTOMRIGHT")
+	overlay.innerGlowOver:SetAlpha(0)
+	overlay.innerGlowOver:SetTexture([[Interface\SpellActivationOverlay\IconAlert]])
+	overlay.innerGlowOver:SetTexCoord(0.00781250, 0.50781250, 0.53515625, 0.78515625)
+
+	-- outer glow
+	overlay.outerGlow = overlay:CreateTexture(name .. "OuterGlow", "ARTWORK")
+	overlay.outerGlow:SetPoint("CENTER")
+	overlay.outerGlow:SetAlpha(0)
+	overlay.outerGlow:SetTexture([[Interface\SpellActivationOverlay\IconAlert]])
+	overlay.outerGlow:SetTexCoord(0.00781250, 0.50781250, 0.27734375, 0.52734375)
+
+	-- outer glow over
+	overlay.outerGlowOver = overlay:CreateTexture(name .. "OuterGlowOver", "ARTWORK")
+	overlay.outerGlowOver:SetPoint("TOPLEFT", overlay.outerGlow, "TOPLEFT")
+	overlay.outerGlowOver:SetPoint("BOTTOMRIGHT", overlay.outerGlow, "BOTTOMRIGHT")
+	overlay.outerGlowOver:SetAlpha(0)
+	overlay.outerGlowOver:SetTexture([[Interface\SpellActivationOverlay\IconAlert]])
+	overlay.outerGlowOver:SetTexCoord(0.00781250, 0.50781250, 0.53515625, 0.78515625)
+
+	-- ants
+	overlay.ants = overlay:CreateTexture(name .. "Ants", "OVERLAY")
+	overlay.ants:SetPoint("CENTER")
+	overlay.ants:SetAlpha(0)
+	overlay.ants:SetTexture([[Interface\SpellActivationOverlay\IconAlertAnts]])
+
+	-- setup antimations
+	overlay.animIn = overlay:CreateAnimationGroup()
+	CreateScaleAnim(overlay.animIn, overlay.spark,          1, 0.2, 1.5, 1.5)
+	CreateAlphaAnim(overlay.animIn, overlay.spark,          1, 0.2, 0, 1)
+	CreateScaleAnim(overlay.animIn, overlay.innerGlow,      1, 0.3, 2, 2)
+	CreateScaleAnim(overlay.animIn, overlay.innerGlowOver,  1, 0.3, 2, 2)
+	CreateAlphaAnim(overlay.animIn, overlay.innerGlowOver,  1, 0.3, 1, 0)
+	CreateScaleAnim(overlay.animIn, overlay.outerGlow,      1, 0.3, 0.5, 0.5)
+	CreateScaleAnim(overlay.animIn, overlay.outerGlowOver,  1, 0.3, 0.5, 0.5)
+	CreateAlphaAnim(overlay.animIn, overlay.outerGlowOver,  1, 0.3, 1, 0)
+	CreateScaleAnim(overlay.animIn, overlay.spark,          1, 0.2, 2/3, 2/3, 0.2)
+	CreateAlphaAnim(overlay.animIn, overlay.spark,          1, 0.2, 1, 0, 0.2)
+	CreateAlphaAnim(overlay.animIn, overlay.innerGlow,      1, 0.2, 1, 0, 0.3)
+	CreateAlphaAnim(overlay.animIn, overlay.ants,           1, 0.2, 0, 1, 0.3)
+	overlay.animIn:SetScript("OnPlay", AnimIn_OnPlay)
+	overlay.animIn:SetScript("OnFinished", AnimIn_OnFinished)
+
+	overlay.animOut = overlay:CreateAnimationGroup()
+	CreateAlphaAnim(overlay.animOut, overlay.outerGlowOver, 1, 0.2, 0, 1)
+	CreateAlphaAnim(overlay.animOut, overlay.ants,          1, 0.2, 1, 0)
+	CreateAlphaAnim(overlay.animOut, overlay.outerGlowOver, 2, 0.2, 1, 0)
+	CreateAlphaAnim(overlay.animOut, overlay.outerGlow,     2, 0.2, 1, 0)
+	overlay.animOut:SetScript("OnFinished", OverlayGlowAnimOutFinished)
+
+	-- scripts
+	overlay:SetScript("OnUpdate", OverlayGlow_OnUpdate)
+	overlay:SetScript("OnHide", OverlayGlow_OnHide)
+
+	overlay.__LBGVersion = MINOR_VERSION
+
+	return overlay
+end
+
+local function GetOverlayGlow()
+	local overlay = tremove(lib.unusedOverlays)
+	if not overlay then
+		overlay = CreateOverlayGlow()
+	end
+	return overlay
+end
+
+function lib.ShowOverlayGlow(frame)
+	if frame.__LBGoverlay then
+		if frame.__LBGoverlay.animOut:IsPlaying() then
+			frame.__LBGoverlay.animOut:Stop()
+			frame.__LBGoverlay.animIn:Play()
+		end
+	else
+		local overlay = GetOverlayGlow()
+		local frameWidth, frameHeight = frame:GetSize()
+		overlay:SetParent(frame)
+		overlay:SetFrameLevel(frame:GetFrameLevel() + 5)
+		overlay:ClearAllPoints()
+		--Make the height/width available before the next frame:
+		overlay:SetSize(frameWidth * 1.4, frameHeight * 1.4)
+		overlay:SetPoint("TOPLEFT", frame, "TOPLEFT", -frameWidth * 0.2, frameHeight * 0.2)
+		overlay:SetPoint("BOTTOMRIGHT", frame, "BOTTOMRIGHT", frameWidth * 0.2, -frameHeight * 0.2)
+		overlay.animIn:Play()
+		frame.__LBGoverlay = overlay
+
+		if Masque and Masque.UpdateSpellAlert and (not frame.overlay or not issecurevariable(frame, "overlay")) then
+			local old_overlay = frame.overlay
+			frame.overlay = overlay
+			Masque:UpdateSpellAlert(frame)
+
+			frame.overlay = old_overlay
+		end
+	end
+end
+
+function lib.HideOverlayGlow(frame)
+	if frame.__LBGoverlay then
+		if frame.__LBGoverlay.animIn:IsPlaying() then
+			frame.__LBGoverlay.animIn:Stop()
+		end
+		if frame:IsVisible() then
+			frame.__LBGoverlay.animOut:Play()
+		else
+			OverlayGlowAnimOutFinished(frame.__LBGoverlay.animOut)
+		end
+	end
+end

--- a/InterruptReminder/Libs/LibButtonGlow-1.0/LibButtonGlow-1.0.toc
+++ b/InterruptReminder/Libs/LibButtonGlow-1.0/LibButtonGlow-1.0.toc
@@ -1,0 +1,14 @@
+## Interface: 90100
+## Title: Lib: ButtonGlow-1.0
+## Notes: Replacement for ActionButton_Show/HideOverlayGlow APIs
+## Author: Nevcairiel
+## X-eMail: h.leppkes@gmail.com
+## X-Category: Library
+## X-License: BSD
+## X-Website: http://www.wowace.com/addons/libbuttonglow-1-0/
+## Version: 1.3.4
+## OptionalDeps: Masque
+
+LibStub\LibStub.lua
+
+LibButtonGlow-1.0.lua

--- a/InterruptReminder/Libs/LibButtonGlow-1.0/LibStub/LibStub.lua
+++ b/InterruptReminder/Libs/LibButtonGlow-1.0/LibStub/LibStub.lua
@@ -1,0 +1,30 @@
+-- LibStub is a simple versioning stub meant for use in Libraries.  http://www.wowace.com/wiki/LibStub for more info
+-- LibStub is hereby placed in the Public Domain Credits: Kaelten, Cladhaire, ckknight, Mikk, Ammo, Nevcairiel, joshborke
+local LIBSTUB_MAJOR, LIBSTUB_MINOR = "LibStub", 2  -- NEVER MAKE THIS AN SVN REVISION! IT NEEDS TO BE USABLE IN ALL REPOS!
+local LibStub = _G[LIBSTUB_MAJOR]
+
+if not LibStub or LibStub.minor < LIBSTUB_MINOR then
+	LibStub = LibStub or {libs = {}, minors = {} }
+	_G[LIBSTUB_MAJOR] = LibStub
+	LibStub.minor = LIBSTUB_MINOR
+	
+	function LibStub:NewLibrary(major, minor)
+		assert(type(major) == "string", "Bad argument #2 to `NewLibrary' (string expected)")
+		minor = assert(tonumber(strmatch(minor, "%d+")), "Minor version must either be a number or contain a number.")
+		
+		local oldminor = self.minors[major]
+		if oldminor and oldminor >= minor then return nil end
+		self.minors[major], self.libs[major] = minor, self.libs[major] or {}
+		return self.libs[major], oldminor
+	end
+	
+	function LibStub:GetLibrary(major, silent)
+		if not self.libs[major] and not silent then
+			error(("Cannot find a library instance of %q."):format(tostring(major)), 2)
+		end
+		return self.libs[major], self.minors[major]
+	end
+	
+	function LibStub:IterateLibraries() return pairs(self.libs) end
+	setmetatable(LibStub, { __call = LibStub.GetLibrary })
+end

--- a/InterruptReminder/Libs/LibButtonGlow-1.0/LibStub/LibStub.toc
+++ b/InterruptReminder/Libs/LibButtonGlow-1.0/LibStub/LibStub.toc
@@ -1,0 +1,9 @@
+## Interface: 20400
+## Title: Lib: LibStub
+## Notes: Universal Library Stub
+## Credits: Kaelten, Cladhaire, ckknight, Mikk, Ammo, Nevcairiel
+## X-Website: http://jira.wowace.com/browse/LS
+## X-Category: Library
+## X-License: Public Domain	
+
+LibStub.lua


### PR DESCRIPTION
Bug fixes:
1. Addon will not get blocked anymore for trying to access blocked functions (although it didn't to begin with) through the usage of LibButtonGlow-1.0
2. When switching to a new target, it will now check if the target is in the process of casting and proceed to act accordingly
3. If the player has multiple interrupts on his action bars, in some cases, the wrong button would get highlighted.

New addition:
1. Now able to capture spells that are currently on cooldown and pass them to a callback handler. If the spell becomes available before the spellcast finishes, the ability will highlight.

General changes:
1. Made all functions related to the addon local rather than global
2. Optimized the code to run more efficiently where possible
3. Added documentation (for my own sanity)